### PR TITLE
Switch to Oklch color model with circular hue interpolation

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -58,7 +58,7 @@ type ColorManager struct {
 	friendlyName string
 	groupConfig  GroupConfig
 
-	previousColor, nextColor Oklab
+	previousColor, nextColor Oklch
 	start, end               time.Time
 }
 


### PR DESCRIPTION
## Summary
- remove remaining Oklab struct and conversions
- convert sRGB and config parsing directly in Oklch space

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b44cc034c4832881c23746f0d3b8bf