### PR TITLE
Add color interpolation tests and fix hue mixing

### DIFF
--- a/color.go
+++ b/color.go
@@ -28,13 +28,17 @@ func OklchWaypoints(from, to Oklch, steps int) []Oklch {
 }
 
 func lerpHue(a, b, t float64) float64 {
-	d := math.Mod(b-a+180, 360) - 180
-	h := a + d*t
-	h = math.Mod(h, 360)
-	if h < 0 {
-		h += 360
-	}
-	return h
+       // Compute the shortest angular difference between a and b.
+       // math.Mod returns a value with the same sign as its argument, so
+       // normalize into [0,360) before adjusting into [-180,180].
+       d := math.Mod(math.Mod(b-a, 360)+360, 360)
+       if d > 180 {
+               d -= 360
+       }
+
+       h := a + d*t
+       h = math.Mod(math.Mod(h, 360)+360, 360)
+       return h
 }
 
 // ---------- sRGB <-> Oklch ----------

--- a/color.go
+++ b/color.go
@@ -28,17 +28,17 @@ func OklchWaypoints(from, to Oklch, steps int) []Oklch {
 }
 
 func lerpHue(a, b, t float64) float64 {
-       // Compute the shortest angular difference between a and b.
-       // math.Mod returns a value with the same sign as its argument, so
-       // normalize into [0,360) before adjusting into [-180,180].
-       d := math.Mod(math.Mod(b-a, 360)+360, 360)
-       if d > 180 {
-               d -= 360
-       }
+	// Compute the shortest angular difference between a and b.
+	// math.Mod returns a value with the same sign as its argument, so
+	// normalize into [0,360) before adjusting into [-180,180].
+	d := math.Mod(math.Mod(b-a, 360)+360, 360)
+	if d > 180 {
+		d -= 360
+	}
 
-       h := a + d*t
-       h = math.Mod(math.Mod(h, 360)+360, 360)
-       return h
+	h := a + d*t
+	h = math.Mod(math.Mod(h, 360)+360, 360)
+	return h
 }
 
 // ---------- sRGB <-> Oklch ----------

--- a/color_test.go
+++ b/color_test.go
@@ -1,80 +1,79 @@
 package main
 
 import (
-    "math"
-    "testing"
+	"math"
+	"testing"
 )
 
 func almostEqual(a, b float64) bool {
-    const eps = 1e-5
-    return math.Abs(a-b) < eps
+	const eps = 1e-5
+	return math.Abs(a-b) < eps
 }
 
 func TestOklchLerp(t *testing.T) {
-    from := Oklch{L: 0.2, C: 0.4, H: 350}
-    to := Oklch{L: 0.8, C: 0.6, H: 10}
+	from := Oklch{L: 0.2, C: 0.4, H: 350}
+	to := Oklch{L: 0.8, C: 0.6, H: 10}
 
-    got := from.Lerp(to, 0.5)
-    if !almostEqual(got.L, 0.5) || !almostEqual(got.C, 0.5) || !almostEqual(got.H, 0) {
-        t.Fatalf("lerp mid: got %#v", got)
-    }
+	got := from.Lerp(to, 0.5)
+	if !almostEqual(got.L, 0.5) || !almostEqual(got.C, 0.5) || !almostEqual(got.H, 0) {
+		t.Fatalf("lerp mid: got %#v", got)
+	}
 
-    if g := from.Lerp(to, 0); !almostEqual(g.L, from.L) || !almostEqual(g.C, from.C) || !almostEqual(g.H, from.H) {
-        t.Fatalf("lerp t=0: got %#v", g)
-    }
+	if g := from.Lerp(to, 0); !almostEqual(g.L, from.L) || !almostEqual(g.C, from.C) || !almostEqual(g.H, from.H) {
+		t.Fatalf("lerp t=0: got %#v", g)
+	}
 
-    if g := from.Lerp(to, 1); !almostEqual(g.L, to.L) || !almostEqual(g.C, to.C) || !almostEqual(g.H, to.H) {
-        t.Fatalf("lerp t=1: got %#v", g)
-    }
+	if g := from.Lerp(to, 1); !almostEqual(g.L, to.L) || !almostEqual(g.C, to.C) || !almostEqual(g.H, to.H) {
+		t.Fatalf("lerp t=1: got %#v", g)
+	}
 }
 
 func TestOklchWaypoints(t *testing.T) {
-    from := Oklch{L: 0, C: 0, H: 0}
-    to := Oklch{L: 1, C: 1, H: 180}
-    steps := 5
-    pts := OklchWaypoints(from, to, steps)
-    if len(pts) != steps {
-        t.Fatalf("expected %d waypoints, got %d", steps, len(pts))
-    }
-    for i := 0; i < steps; i++ {
-        expected := from.Lerp(to, float64(i)/float64(steps-1))
-        got := pts[i]
-        if !almostEqual(got.L, expected.L) || !almostEqual(got.C, expected.C) || !almostEqual(got.H, expected.H) {
-            t.Fatalf("waypoint %d: got %#v want %#v", i, got, expected)
-        }
-    }
+	from := Oklch{L: 0, C: 0, H: 0}
+	to := Oklch{L: 1, C: 1, H: 180}
+	steps := 5
+	pts := OklchWaypoints(from, to, steps)
+	if len(pts) != steps {
+		t.Fatalf("expected %d waypoints, got %d", steps, len(pts))
+	}
+	for i := 0; i < steps; i++ {
+		expected := from.Lerp(to, float64(i)/float64(steps-1))
+		got := pts[i]
+		if !almostEqual(got.L, expected.L) || !almostEqual(got.C, expected.C) || !almostEqual(got.H, expected.H) {
+			t.Fatalf("waypoint %d: got %#v want %#v", i, got, expected)
+		}
+	}
 
-    small := OklchWaypoints(from, to, 1)
-    if len(small) != 2 {
-        t.Fatalf("expected 2 waypoints when steps<2, got %d", len(small))
-    }
-    if !almostEqual(small[0].L, from.L) || !almostEqual(small[1].L, to.L) {
-        t.Fatalf("unexpected endpoints %#v", small)
-    }
+	small := OklchWaypoints(from, to, 1)
+	if len(small) != 2 {
+		t.Fatalf("expected 2 waypoints when steps<2, got %d", len(small))
+	}
+	if !almostEqual(small[0].L, from.L) || !almostEqual(small[1].L, to.L) {
+		t.Fatalf("unexpected endpoints %#v", small)
+	}
 }
 
 func TestSRGBRoundTrip(t *testing.T) {
-    r, g, b := 0.25, 0.5, 0.75
-    o := OklchFromSRGB(r, g, b)
-    rr, gg, bb := o.ToSRGB()
-    if !almostEqual(r, rr) || !almostEqual(g, gg) || !almostEqual(b, bb) {
-        t.Fatalf("round trip mismatch: got %f %f %f", rr, gg, bb)
-    }
+	r, g, b := 0.25, 0.5, 0.75
+	o := OklchFromSRGB(r, g, b)
+	rr, gg, bb := o.ToSRGB()
+	if !almostEqual(r, rr) || !almostEqual(g, gg) || !almostEqual(b, bb) {
+		t.Fatalf("round trip mismatch: got %f %f %f", rr, gg, bb)
+	}
 }
 
 func TestToHSV(t *testing.T) {
-    o := OklchFromSRGB(1, 0, 0)
-    h, s, v := o.ToHSV()
-    if !almostEqual(h, 0) || !almostEqual(s, 1) || !almostEqual(v, 1) {
-        t.Fatalf("HSV for red: got %f %f %f", h, s, v)
-    }
+	o := OklchFromSRGB(1, 0, 0)
+	h, s, v := o.ToHSV()
+	if !almostEqual(h, 0) || !almostEqual(s, 1) || !almostEqual(v, 1) {
+		t.Fatalf("HSV for red: got %f %f %f", h, s, v)
+	}
 }
 
 func TestToXY(t *testing.T) {
-    o := OklchFromSRGB(1, 1, 1)
-    x, y := o.ToXY()
-    if !almostEqual(x, 0.312727) || !almostEqual(y, 0.329023) {
-        t.Fatalf("xy for white: got %f %f", x, y)
-    }
+	o := OklchFromSRGB(1, 1, 1)
+	x, y := o.ToXY()
+	if !almostEqual(x, 0.312727) || !almostEqual(y, 0.329023) {
+		t.Fatalf("xy for white: got %f %f", x, y)
+	}
 }
-

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "math"
+    "testing"
+)
+
+func almostEqual(a, b float64) bool {
+    const eps = 1e-5
+    return math.Abs(a-b) < eps
+}
+
+func TestOklchLerp(t *testing.T) {
+    from := Oklch{L: 0.2, C: 0.4, H: 350}
+    to := Oklch{L: 0.8, C: 0.6, H: 10}
+
+    got := from.Lerp(to, 0.5)
+    if !almostEqual(got.L, 0.5) || !almostEqual(got.C, 0.5) || !almostEqual(got.H, 0) {
+        t.Fatalf("lerp mid: got %#v", got)
+    }
+
+    if g := from.Lerp(to, 0); !almostEqual(g.L, from.L) || !almostEqual(g.C, from.C) || !almostEqual(g.H, from.H) {
+        t.Fatalf("lerp t=0: got %#v", g)
+    }
+
+    if g := from.Lerp(to, 1); !almostEqual(g.L, to.L) || !almostEqual(g.C, to.C) || !almostEqual(g.H, to.H) {
+        t.Fatalf("lerp t=1: got %#v", g)
+    }
+}
+
+func TestOklchWaypoints(t *testing.T) {
+    from := Oklch{L: 0, C: 0, H: 0}
+    to := Oklch{L: 1, C: 1, H: 180}
+    steps := 5
+    pts := OklchWaypoints(from, to, steps)
+    if len(pts) != steps {
+        t.Fatalf("expected %d waypoints, got %d", steps, len(pts))
+    }
+    for i := 0; i < steps; i++ {
+        expected := from.Lerp(to, float64(i)/float64(steps-1))
+        got := pts[i]
+        if !almostEqual(got.L, expected.L) || !almostEqual(got.C, expected.C) || !almostEqual(got.H, expected.H) {
+            t.Fatalf("waypoint %d: got %#v want %#v", i, got, expected)
+        }
+    }
+
+    small := OklchWaypoints(from, to, 1)
+    if len(small) != 2 {
+        t.Fatalf("expected 2 waypoints when steps<2, got %d", len(small))
+    }
+    if !almostEqual(small[0].L, from.L) || !almostEqual(small[1].L, to.L) {
+        t.Fatalf("unexpected endpoints %#v", small)
+    }
+}
+
+func TestSRGBRoundTrip(t *testing.T) {
+    r, g, b := 0.25, 0.5, 0.75
+    o := OklchFromSRGB(r, g, b)
+    rr, gg, bb := o.ToSRGB()
+    if !almostEqual(r, rr) || !almostEqual(g, gg) || !almostEqual(b, bb) {
+        t.Fatalf("round trip mismatch: got %f %f %f", rr, gg, bb)
+    }
+}
+
+func TestToHSV(t *testing.T) {
+    o := OklchFromSRGB(1, 0, 0)
+    h, s, v := o.ToHSV()
+    if !almostEqual(h, 0) || !almostEqual(s, 1) || !almostEqual(v, 1) {
+        t.Fatalf("HSV for red: got %f %f %f", h, s, v)
+    }
+}
+
+func TestToXY(t *testing.T) {
+    o := OklchFromSRGB(1, 1, 1)
+    x, y := o.ToXY()
+    if !almostEqual(x, 0.312727) || !almostEqual(y, 0.329023) {
+        t.Fatalf("xy for white: got %f %f", x, y)
+    }
+}
+


### PR DESCRIPTION
## Summary
- correct hue interpolation to always take shortest arc and normalize
- add tests for color blending, waypoints, and color conversions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b454fbbea4832890f662ae11c6e3c8